### PR TITLE
Use log/slog and log using context.Context

### DIFF
--- a/context.go
+++ b/context.go
@@ -3,8 +3,9 @@ package crud
 import (
 	"context"
 	stdsql "database/sql"
+	"time"
 
-	"github.com/azer/logger"
+	"log/slog"
 )
 
 type WithContext struct {
@@ -16,24 +17,18 @@ type WithContext struct {
 
 // Execute any SQL query on the context client. Returns sql.Result.
 func (ctx *WithContext) Exec(sql string, params ...interface{}) (stdsql.Result, error) {
-	timer := log.Timer()
+	start := time.Now()
 	result, err := ctx.DB.ExecContext(ctx.Context, sql, params...)
-	timer.End("Executed SQL query.", logger.Attrs{
-		ctx.IdKey: ctx.Id,
-		"sql":     sql,
-	})
+	slog.InfoContext(ctx.Context, "Executed SQL query", "sql", sql, "took", time.Since(start))
 
 	return result, err
 }
 
 // Execute any SQL query on the context client. Returns sql.Rows.
 func (ctx *WithContext) Query(sql string, params ...interface{}) (*stdsql.Rows, error) {
-	timer := log.Timer()
+	start := time.Now()
 	result, err := ctx.DB.QueryContext(ctx.Context, sql, params...)
-	timer.End("Run SQL query.", logger.Attrs{
-		ctx.IdKey: ctx.Id,
-		"sql":     sql,
-	})
+	slog.InfoContext(ctx.Context, "Ran SQL query", "sql", sql, "took", time.Since(start))
 
 	return result, err
 }

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/azer/crud/v2
 
 require (
-	github.com/azer/logger v1.0.0
 	github.com/azer/snakecase v1.0.0
 	github.com/go-sql-driver/mysql v1.4.0
 	github.com/jinzhu/inflection v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,3 @@
-github.com/azer/is-terminal v1.0.0 h1:COvj8jmg2xMz0CqHn4Uu8X1m7Dmzmu0CpciBaLtJQBg=
-github.com/azer/is-terminal v1.0.0/go.mod h1:5geuIpRQvdv6g/Q1MwXHbmNUlFLg8QcheGk4dZOmxQU=
-github.com/azer/logger v1.0.0 h1:3T4BnTLyndJWHajOyECt2kAhnvP30KCrVAkYcMjHrXk=
-github.com/azer/logger v1.0.0/go.mod h1:iaDID7UeBTyUh31bjGFlLkr87k23z/mHMMLzt6YQQHU=
 github.com/azer/snakecase v1.0.0 h1:Gr9hfYVh6U96aUoGEbJK400H9KTiz6yCIYk3EN8n9hY=
 github.com/azer/snakecase v1.0.0/go.mod h1:iApMeoHF0YlMPzCwqH/d59E3w2s8SeO4rGK+iGClS8Y=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
since we log with the context now, there's no need to store any
transaction ID or key, etc. the parent is controlling that and passing
it inside the context
