### PR TITLE
Support generated columns

### DIFF
--- a/row.go
+++ b/row.go
@@ -54,12 +54,11 @@ func CollectRows(st interface{}, rows []*RowValue) ([]*RowValue, error) {
 	iter := NewFieldIteration(st)
 	for iter.Next() {
 		sqlOptions, err := iter.SQLOptions()
-
 		if err != nil {
 			return nil, err
 		}
 
-		if sqlOptions.Ignore {
+		if sqlOptions.Ignore || sqlOptions.Generated {
 			continue
 		}
 

--- a/sql/options.go
+++ b/sql/options.go
@@ -69,6 +69,11 @@ func NewOptions(input string) (*Options, error) {
 			continue
 		}
 
+		if part == "generated" {
+			options.Generated = true
+			continue
+		}
+
 		return nil, errors.New(fmt.Sprintf("Unrecognized SQL option: %s", part))
 	}
 
@@ -87,6 +92,7 @@ type Options struct {
 	IsUnsigned         bool
 	IsRequired         bool
 	Ignore             bool
+	Generated          bool
 	TableName          string
 }
 

--- a/table.go
+++ b/table.go
@@ -68,7 +68,7 @@ func (table *Table) SQLUpdateColumnSet() []string {
 	columns := []string{}
 
 	for _, f := range table.Fields {
-		if f.SQL.Ignore || f.SQL.IsAutoIncrementing {
+		if f.SQL.Ignore || f.SQL.IsAutoIncrementing || f.SQL.Generated {
 			continue
 		}
 
@@ -82,7 +82,7 @@ func (table *Table) SQLUpdateValueSet() []interface{} {
 	values := []interface{}{}
 
 	for _, f := range table.Fields {
-		if f.SQL.Ignore || f.SQL.IsAutoIncrementing {
+		if f.SQL.Ignore || f.SQL.IsAutoIncrementing || f.SQL.Generated {
 			continue
 		}
 


### PR DESCRIPTION
supports struct definitions like 
```
type Table struct { 
    Column string `sql:"string generated"`
}
```

which means it should be used for SELECT etc statements, but not INSERT or UPDATE 